### PR TITLE
Rename niveristand-slsc-switch-message-library

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/CONTRIBUTING.md).
+- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-message-library/blob/main/CONTRIBUTING.md).
 
-TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/CONTRIBUTING.md).
+TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-message-library/blob/main/CONTRIBUTING.md).
 
 ### What does this Pull Request accomplish?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to niveristand-slsc-switch-message-library
+# Contributing to niveristand-routing-and-faulting-message-library
 
-Contributions to niveristand-slsc-switch-message-library are welcome from all!
+Contributions to niveristand-routing-and-faulting-message-library are welcome from all!
 
-niveristand-slsc-switch-message-library is managed via [git](https://git-scm.com), with the canonical upstream
-repository hosted on [GitHub](https://github.com/ni/niveristand-slsc-switch-message-library/).
+niveristand-routing-and-faulting-message-library is managed via [git](https://git-scm.com), with the canonical upstream
+repository hosted on [GitHub](https://github.com/ni/niveristand-routing-and-faulting-message-library/).
 
-niveristand-slsc-switch-message-library follows a pull-request model for development.  If you wish to
+niveristand-routing-and-faulting-message-library follows a pull-request model for development.  If you wish to
 contribute, you will need to create a GitHub account, fork this project, push a
 branch with your changes to your project, and then submit a pull request.
 
@@ -51,5 +51,5 @@ using the `RunVITester` operation provided by the [testing tools](https://github
 
 (taken from [developercertificate.org](https://developercertificate.org/))
 
-See [LICENSE](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/LICENSE)
-for details about how niveristand-slsc-switch-message-library is licensed.
+See [LICENSE](https://github.com/ni/niveristand-routing-and-faulting-message-library/blob/main/LICENSE)
+for details about how niveristand-routing-and-faulting-message-library is licensed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# SLSC Switch Message Library
+# Routing and Faulting Message Library
 
-This library is a concrete NI-SLSC Switch instantiation of the Switch consumer defined by the [Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library).
+This library provides concrete implementations of the Switch consumer defined by the [Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library).
+
+The following implementations are provided:
+
+- NI-SLSC Switch
 
 ## LabVIEW Version
 LabVIEW 2017

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This library provides concrete implementations of the Switch consumer defined by
 The following implementations are provided:
 
 - NI-SLSC Switch
+- NI-SWITCH
 
 ## LabVIEW Version
 LabVIEW 2017
@@ -12,6 +13,7 @@ LabVIEW 2017
 ## Dependencies
 - The packed library build from [NI VeriStand Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library).
 - NI-SLSC Switch 19.1+ (included with NI-SLSC 19.5+)
+- NI-SWITCH
 - The [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools) to run automated tests.
 
 ## Git History & Rebasing Policy


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-switch-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Rename this repository to `niveristand-routing-and-faulting-message-library`.

Additional changes will be needed outside this repository to handle this change:

- https://github.com/ni/niveristand-routing-and-faulting-custom-device/pull/218
- Changes to the feed-build tool.

### Why should this Pull Request be merged?

We anticipate implementations of the message library aside from SLSC Switch, and want them co-located.

### What testing has been done?

None.
