### PR TITLE
Add 2023 to build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 def lvVersions = [
   32 : ['2019', '2020'],
-  64 : ['2021']
+  64 : ['2021', '2023']
 ]
 
 List<String> dependencies = ['niveristand-custom-device-message-library']


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-message-library/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create a LV 2023-based build of the messaging library
Note: leaving 2019 enabled until we disable it from all dependent repos

### Why should this Pull Request be merged?

We need a good build against in-dev 2023 to run automated testing.

### What testing has been done?

PR build.
