### PR TITLE
only trigger from cd message library CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,10 @@ resources:
   pipelines:
     - pipeline: VeristandMessageLibrary
       source:   ni.niveristand-custom-device-message-library
-      trigger:  true
+      trigger:
+        branches:
+          include:
+            - main
 
 stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-routing-and-faulting-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changes pipeline completion trigger to only activate when changes are made to main.

### Why should this Pull Request be merged?

Currently pipelines are being triggered off of all builds, we should just trigger off of CI builds when changes are merged to main.

### What testing has been done?

Tested with imitation-cd beforehand, requires a CI build or manual build to activate pipeline completion trigger.